### PR TITLE
Send more data about resolved imports

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -62,10 +62,10 @@ function handleMessage(json) {
 
           return uniqueImports.concat(option);
         }, [])
-        .map(({ displayName, importPath }) => {
+        .map(({ displayName, data }) => {
           return {
             label: displayName,
-            importPath
+            data
           };
         });
 
@@ -75,10 +75,10 @@ function handleMessage(json) {
           return Promise.resolve(resolutions);
         }
 
-        const { importPath } = selected;
+        const { data } = selected;
         const resolution = {
           name,
-          path: importPath
+          data
         };
 
         return requestResolutions(
@@ -90,8 +90,8 @@ function handleMessage(json) {
 
     requestResolutions(imports).then(resolutions => {
       const imports = resolutions.reduce((imports, resolution) => {
-        const { name, path } = resolution;
-        imports[name] = path;
+        const { name, data } = resolution;
+        imports[name] = data;
         return imports;
       }, {});
 


### PR DESCRIPTION
A recent commit in import-js made it so that we send down more
information about unresolved imports:
Galooshi/import-js@194ed52

This was in service of allowing a module to export a named export equal
to the module name itself. Before said commit, we didn't have enough
information in the json object sent down to the client to target the
right import.  Now, we have a full object describing the import.

Same as
https://github.com/Galooshi/atom-import-js/commit/2e47e808cc2d464442054841e9bbf8a83b162c8b
,
https://github.com/Galooshi/vim-import-js/commit/862ca76e685e8563385b0dcd8f7d83e47ba2ce09
and
https://github.com/Galooshi/sublime-import-js/commit/e9fd52b9d422997231a823cdbb768024bb74a60e