### PR TITLE
Fix #10: Apply edits sequencially

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -24,9 +24,11 @@ function projectDirectoryPath() {
 }
 
 function applyEdits(edits) {
-  const workspaceEdit = new WorkspaceEdit();
-  workspaceEdit.set(currentDocument().uri, edits);
-  vscode.workspace.applyEdit(workspaceEdit);
+  edits.forEach(edit => {
+    const workspaceEdit = new WorkspaceEdit();
+    workspaceEdit.set(currentDocument().uri, [edit]);
+    vscode.workspace.applyEdit(workspaceEdit);
+  })
 }
 
 function syncFileContents(newText) {


### PR DESCRIPTION
Fix #10 

The generated `TextEdit` instances from `textEditsForDiff` has to be applied sequentially in VSCode to get the right result.

When applying as a batch of TextEdit instances, the positions defined for each range references the content when the command is invoked not the updated state after each edit.